### PR TITLE
Add provides without the merge conflict

### DIFF
--- a/META.info
+++ b/META.info
@@ -4,6 +4,9 @@
     "description" : "easily search for system users in Unix-based systems",
     "author" : "David Farrell",
     "depends" : [ ],
+    "provides" : {
+        "System::Passwd" : "lib/System/Passwd.pm6",
+        "System::Passwd::User" : "lib/System/Passwd/User.pm6"
+    },
     "source-url" : "git://github.com/sillymoose/System-Passwd.git"
 }
-


### PR DESCRIPTION
Hi,
with the latest panda a module can't be found after being installed without the depends section in the META.info.  For me this is causing a problem for automated testing.

Thanks,